### PR TITLE
fix the index issue to do with bgzip and tabix

### DIFF
--- a/burden/tool_runners/regenie_runner.py
+++ b/burden/tool_runners/regenie_runner.py
@@ -360,10 +360,10 @@ class REGENIERunner(ToolRunner):
                     manhattan_plotter.plot()[0].rename(plot_dir / f'{mask}.{maf}.genes.REGENIE.png')
 
             # Write to disk
-            regenie_table.to_csv(path_or_buf=gene_out, index=True, sep="\t", na_rep='NA')
+            regenie_table.to_csv(path_or_buf=gene_out, index=False, sep="\t", na_rep='NA')
 
         # And bgzip and tabix...
-        outputs.extend(bgzip_and_tabix(regenie_gene_out, comment_char='c', sequence_row=2, begin_row=3, end_row=4))
+        outputs.extend(bgzip_and_tabix(regenie_gene_out, comment_char='c', sequence_row=1, begin_row=2, end_row=3))
 
         if self._association_pack.run_marker_tests:
 


### PR DESCRIPTION
Small fix to export the regenie table with no index so that the indexing command works from bgzip_and_tabix